### PR TITLE
changed to response.url.scheme instead of is_ssl

### DIFF
--- a/httpx_ntlm/httpx_ntlm.py
+++ b/httpx_ntlm/httpx_ntlm.py
@@ -150,9 +150,9 @@ class HttpNtlmAuth(Auth):
         :return: The hash of the DER encoded certificate at the request_url or None if
         not an HTTPS endpoint
         """
-        if self.send_cbt and response.url.is_ssl:
+        if self.send_cbt and response.url.scheme == "https":
             if response.url.port is None:
-                port = {"https":"443", "http": "80"}.get(response.url.scheme, "")
+                port = "443"
             else:
                 port = response.url.port
             cert = get_server_certificate((response.url.host, port))


### PR DESCRIPTION
fixes #1 
Second attempt.
The `is_ssl` property has been deprecated with httpx 0.15, so needed to switch to check the response.url.scheme instead.
Also removed the port 80 and just use 443 when it's https and port is None.