### PR TITLE
Migrate from deprecated ntlm-auth to pyspnego

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ adaptation of https://github.com/requests/requests-ntlm.
 Usage
 -----
 
-``HttpNtlmAuth`` extends HTTPX ``Auth`` base calss, so usage is simple:
+``HttpNtlmAuth`` extends HTTPX ``Auth`` base class, so usage is simple:
 
 .. code:: python
 
@@ -38,8 +38,7 @@ Requirements
 ------------
 
 - httpx_
-- ntlm-auth_
+- pyspnego_
 
 .. _httpx: https://github.com/encode/httpx
-.. _ntlm-auth: https://github.com/jborean93/ntlm-auth
-
+.. _pyspnego: https://github.com/jborean93/pyspnego

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-httpx>=0.18.*
+httpx>=0.21.*
 ntlm-auth==1.5.*
-cryptography==3.4.*
+cryptography==36.0.*
 flask
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 httpx>=0.21.*
-ntlm-auth==1.5.*
+pyspnego==0.3.*
 cryptography==36.0.*
 flask
 pytest

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ from setuptools import setup
 
 setup(
     name="httpx_ntlm",
-    version="0.0.11",
+    version="1.0.0",
     packages=["httpx_ntlm"],
     install_requires=[
         "httpx>=0.21.*",
-        "ntlm-auth==1.5.*",
+        "pyspnego==0.3.*",
         "cryptography==36.0.*",
     ],
     provides=["httpx_ntlm"],

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,13 @@ from setuptools import setup
 
 setup(
     name="httpx_ntlm",
-    version="0.0.10",
+    version="0.0.11",
     packages=["httpx_ntlm"],
-    install_requires=["httpx>=0.18.*", "ntlm-auth==1.5.*", "cryptography==3.4.*"],
+    install_requires=[
+        "httpx>=0.21.*",
+        "ntlm-auth==1.5.*",
+        "cryptography==36.0.*",
+    ],
     provides=["httpx_ntlm"],
     author="Ludovic VAUGEOIS",
     author_email="ulodciv@gmail.com",


### PR DESCRIPTION
The `ntlm-auth` library is now [deprecated](https://github.com/jborean93/ntlm-auth#this-library-is-deprecated-in-favour-of-pyspnego) ([417db8b6fb0f9b5f86f314e257b8a4893f74c057](https://github.com/jborean93/ntlm-auth/commit/417db8b6fb0f9b5f86f314e257b8a4893f74c057)) in favour of [PySPNEGO](https://github.com/jborean93/pyspnego) of the same author.

This PR is _heavily_ based on [this](https://github.com/requests/requests-ntlm/pull/126) pull request by J. Hill-Daniel (@clubby789) in the `requests-ntlm` sister library.
